### PR TITLE
Graphql GitHub repository listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,8 @@ require (
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20190625031733-ee671ab25ff0
+	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/sirupsen/logrus v1.3.0
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff // indirect
 	github.com/spf13/pflag v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
+	github.com/prometheus/common v0.2.0
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20190625031733-ee671ab25ff0
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect

--- a/hookd/pkg/auth/common.go
+++ b/hookd/pkg/auth/common.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	gh "github.com/google/go-github/v23/github"
+	"github.com/shurcooL/githubv4"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -120,6 +121,15 @@ func userClient(oauthtoken string) *gh.Client {
 
 	tc := oauth2.NewClient(context.Background(), ts)
 	return gh.NewClient(tc)
+}
+
+func graphqlClient(oauthtoken string) (*githubv4.Client) {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: oauthtoken,
+	})
+
+	tc := oauth2.NewClient(context.Background(), ts)
+	return githubv4.NewClient(tc)
 }
 
 func templateWithBase(t string) (*template.Template, error) {

--- a/hookd/pkg/auth/proxy.go
+++ b/hookd/pkg/auth/proxy.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sort"
 
@@ -65,8 +64,8 @@ func (h *RepositoriesProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}
 
 	type repo struct {
-		Name             githubv4.String `json:"name"`
-		NameWithOwner    githubv4.String `json:"full_name"`
+		Name                githubv4.String `json:"name"`
+		NameWithOwner       githubv4.String `json:"full_name"`
 		ViewerCanAdminister githubv4.Boolean
 	}
 
@@ -109,8 +108,6 @@ func (h *RepositoriesProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		}
 		variables["repositoriesCursor"] = githubv4.NewString(query.Organization.Repositories.PageInfo.EndCursor)
 	}
-	fmt.Println(allRepos)
-	fmt.Println(len(allRepos))
 
 	sort.Slice(allRepos, func(i, j int) bool {
 		return allRepos[i].Name < allRepos[j].Name

--- a/hookd/pkg/github/repository.go
+++ b/hookd/pkg/github/repository.go
@@ -1,0 +1,55 @@
+package github
+
+import (
+	"context"
+
+	"github.com/prometheus/common/log"
+	"github.com/shurcooL/githubv4"
+)
+
+type repo struct {
+	Name                githubv4.String `json:"name"`
+	NameWithOwner       githubv4.String `json:"full_name"`
+	ViewerCanAdminister githubv4.Boolean
+}
+
+func GetRepositories(client *githubv4.Client) (allRepos []repo, err error) {
+	var query struct {
+		Organization struct {
+			Repositories struct {
+				Nodes      []repo
+				TotalCount githubv4.Int
+
+				PageInfo struct {
+					EndCursor   githubv4.String
+					HasNextPage bool
+				}
+			} `graphql:"repositories(first:100, after: $repositoriesCursor)"`
+		} `graphql:"organization(login: $organization)"`
+	}
+
+	variables := map[string]interface{}{
+		"organization":       githubv4.String("navikt"),
+		"repositoriesCursor": (*githubv4.String)(nil),
+	}
+
+	for {
+		err = client.Query(context.Background(), &query, variables)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		for _, repo := range query.Organization.Repositories.Nodes {
+			if repo.ViewerCanAdminister {
+				allRepos = append(allRepos, repo)
+			}
+		}
+
+		if !query.Organization.Repositories.PageInfo.HasNextPage {
+			break
+		}
+		variables["repositoriesCursor"] = githubv4.NewString(query.Organization.Repositories.PageInfo.EndCursor)
+	}
+	return
+}


### PR DESCRIPTION
I've switched the function doing the repository listing and filtering over to GraphQL from the previous rest API. And the performance improvement in terms of load times is that the new function is twice as fast. 

This is manily due to a few reasons and they are more I/O related;
- GraphQL API is allowed to paginate by a 100 repos at a time.
- I can specify exactly what I want returned so the returned blobs are much smaller
