### PR TITLE
hookd: refactor options internal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,8 @@ Check out the repository and run `make`. Dependencies will download automaticall
 ### External dependencies
 Start the external dependencies by running `docker-compose up`. This will start local Kafka and S3 servers.
 
-The S3 access and secret keys are as follows:
-
-```
-export S3_ACCESS_KEY=accesskey
-export S3_SECRET_KEY=secretkey
-```
+The S3 access and secret keys are `accesskey` and `secretkey` respectively. Conveniently, these are
+the default options for _hookd_ as well, so you don't have to configure anything.
 
 ### Development on the frontend application
 To enable the frontend on your local instance, you need to configure hookd against the staging deployment application at Github.
@@ -76,20 +72,22 @@ Configure hookd as follows:
 --github-enabled=true \
 --github-install-id=XXXXXX \
 --github-app-id=XXXXXX \
+--github-client-id=XXXXXX \
+--github-client-secret=XXXXXX \
 --github-key-file=/path/to/private-key.pem \
 ```
 
 ### Simulating Github deployment requests
 When you want to send webhooks to _hookd_ without invoking Github, you can use the `mkdeploy` tool, which simulates these requests.
 
-Start a local Kafka instance as described above. Now run your local hookd instance, disabling Github interactions:
+Start a local Kafka instance as described above, and then run your local hookd instance.
 ```
-hookd/hookd --github-enabled=false --listen-address=127.0.0.1:8080
+./hookd/hookd
 ```
 
 If you want to deploy, you want to start up `deployd` as well:
 ```
-deployd/deployd
+./deployd/deployd
 ```
 
 Compile the `mkdeploy` tool:

--- a/hookd/cmd/hookd/main.go
+++ b/hookd/cmd/hookd/main.go
@@ -30,13 +30,13 @@ var (
 )
 
 func init() {
-	flag.BoolVar(&cfg.EnableGithub, "github-enabled", cfg.EnableGithub, "Enable connections to Github.")
-	flag.StringVar(&cfg.WebhookSecret, "github-webhook-secret", cfg.WebhookSecret, "Github pre-shared webhook secret key.")
-	flag.IntVar(&cfg.ApplicationID, "github-app-id", cfg.ApplicationID, "Github App ID.")
-	flag.IntVar(&cfg.InstallID, "github-install-id", cfg.InstallID, "Github App installation ID.")
-	flag.StringVar(&cfg.KeyFile, "github-key-file", cfg.KeyFile, "Path to PEM key owned by Github App.")
-	flag.StringVar(&cfg.ClientID, "github-client-id", cfg.ClientID, "Client ID of the Github App.")
-	flag.StringVar(&cfg.ClientSecret, "github-client-secret", cfg.ClientSecret, "Client secret of the GitHub App.")
+	flag.BoolVar(&cfg.Github.EnableGithub, "github-enabled", cfg.Github.EnableGithub, "Enable connections to Github.")
+	flag.StringVar(&cfg.Github.WebhookSecret, "github-webhook-secret", cfg.Github.WebhookSecret, "Github pre-shared webhook secret key.")
+	flag.IntVar(&cfg.Github.ApplicationID, "github-app-id", cfg.Github.ApplicationID, "Github App ID.")
+	flag.IntVar(&cfg.Github.InstallID, "github-install-id", cfg.Github.InstallID, "Github App installation ID.")
+	flag.StringVar(&cfg.Github.KeyFile, "github-key-file", cfg.Github.KeyFile, "Path to PEM key owned by Github App.")
+	flag.StringVar(&cfg.Github.ClientID, "github-client-id", cfg.Github.ClientID, "Client ID of the Github App.")
+	flag.StringVar(&cfg.Github.ClientSecret, "github-client-secret", cfg.Github.ClientSecret, "Client secret of the GitHub App.")
 
 	flag.StringVar(&cfg.BaseURL, "base-url", cfg.BaseURL, "Base URL where hookd can be reached.")
 	flag.StringVar(&cfg.ListenAddress, "listen-address", cfg.ListenAddress, "IP:PORT")
@@ -74,7 +74,7 @@ func run() error {
 
 	sarama.Logger = kafkaLogger
 
-	if cfg.EnableGithub && (cfg.ApplicationID == 0 || cfg.InstallID == 0) {
+	if cfg.Github.EnableGithub && (cfg.Github.ApplicationID == 0 || cfg.Github.InstallID == 0) {
 		return fmt.Errorf("--github-install-id and --github-app-id must be specified when --github-enabled=true")
 	}
 
@@ -96,8 +96,8 @@ func run() error {
 
 	var installationClient *gh.Client
 
-	if cfg.EnableGithub {
-		installationClient, err = github.InstallationClient(cfg.ApplicationID, cfg.InstallID, cfg.KeyFile)
+	if cfg.Github.EnableGithub {
+		installationClient, err = github.InstallationClient(cfg.Github.ApplicationID, cfg.Github.InstallID, cfg.Github.KeyFile)
 		if err != nil {
 			return fmt.Errorf("cannot instantiate Github installation client: %s", err)
 		}
@@ -109,17 +109,17 @@ func run() error {
 	deploymentHandler := &server.DeploymentHandler{
 		DeploymentRequest:     requestChan,
 		DeploymentStatus:      statusChan,
-		SecretToken:           cfg.WebhookSecret,
+		SecretToken:           cfg.Github.WebhookSecret,
 		TeamRepositoryStorage: teamRepositoryStorage,
 	}
 
 	http.Handle("/events", deploymentHandler)
 	http.Handle("/auth/login", &auth.LoginHandler{
-		ClientID: cfg.ClientID,
+		ClientID: cfg.Github.ClientID,
 	})
 	http.Handle("/auth/callback", &auth.CallbackHandler{
-		ClientID:     cfg.ClientID,
-		ClientSecret: cfg.ClientSecret,
+		ClientID:     cfg.Github.ClientID,
+		ClientSecret: cfg.Github.ClientSecret,
 	})
 	http.Handle("/auth/form", &auth.FormHandler{})
 	http.Handle("/auth/submit", &auth.SubmittedFormHandler{
@@ -228,7 +228,7 @@ func run() error {
 			logger := log.WithFields(status.LogFields())
 			logger.Trace("Received deployment status")
 
-			if !cfg.EnableGithub {
+			if !cfg.Github.EnableGithub {
 				logger.Warn("Github is disabled; deployment status discarded")
 				metrics.DeploymentStatus(status, 0)
 				continue

--- a/hookd/cmd/hookd/main.go
+++ b/hookd/cmd/hookd/main.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	flag.BoolVar(&cfg.Github.EnableGithub, "github-enabled", cfg.Github.EnableGithub, "Enable connections to Github.")
+	flag.BoolVar(&cfg.Github.Enabled, "github-enabled", cfg.Github.Enabled, "Enable connections to Github.")
 	flag.StringVar(&cfg.Github.WebhookSecret, "github-webhook-secret", cfg.Github.WebhookSecret, "Github pre-shared webhook secret key.")
 	flag.IntVar(&cfg.Github.ApplicationID, "github-app-id", cfg.Github.ApplicationID, "Github App ID.")
 	flag.IntVar(&cfg.Github.InstallID, "github-install-id", cfg.Github.InstallID, "Github App installation ID.")
@@ -74,7 +74,7 @@ func run() error {
 
 	sarama.Logger = kafkaLogger
 
-	if cfg.Github.EnableGithub && (cfg.Github.ApplicationID == 0 || cfg.Github.InstallID == 0) {
+	if cfg.Github.Enabled && (cfg.Github.ApplicationID == 0 || cfg.Github.InstallID == 0) {
 		return fmt.Errorf("--github-install-id and --github-app-id must be specified when --github-enabled=true")
 	}
 
@@ -96,7 +96,7 @@ func run() error {
 
 	var installationClient *gh.Client
 
-	if cfg.Github.EnableGithub {
+	if cfg.Github.Enabled {
 		installationClient, err = github.InstallationClient(cfg.Github.ApplicationID, cfg.Github.InstallID, cfg.Github.KeyFile)
 		if err != nil {
 			return fmt.Errorf("cannot instantiate Github installation client: %s", err)
@@ -228,7 +228,7 @@ func run() error {
 			logger := log.WithFields(status.LogFields())
 			logger.Trace("Received deployment status")
 
-			if !cfg.Github.EnableGithub {
+			if !cfg.Github.Enabled {
 				logger.Warn("Github is disabled; deployment status discarded")
 				metrics.DeploymentStatus(status, 0)
 				continue

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/navikt/deployment/common/pkg/kafka"
 )
@@ -32,28 +33,45 @@ type Config struct {
 	MetricsPath   string
 }
 
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+func parseBool(str string) bool {
+	b, _ := strconv.ParseBool(str)
+	return b
+}
+
+func parseInt(str string) int {
+	i, _ := strconv.Atoi(str)
+	return i
+}
+
 func DefaultConfig() *Config {
 	return &Config{
-		EnableGithub:  true,
-		ListenAddress: ":8080",
-		LogFormat:     "text",
-		LogLevel:      "debug",
-		BaseURL:       "http://localhost:8080",
-		WebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),
-		ApplicationID: 0,
-		InstallID:     0,
-		KeyFile:       "private-key.pem",
+		BaseURL:       getEnv("BASE_URL", "http://localhost:8080"),
+		ApplicationID: parseInt(getEnv("GITHUB_APP_ID", "0")),
+		ClientID:      getEnv("GITHUB_CLIENT_ID", ""),
+		ClientSecret:  getEnv("GITHUB_CLIENT_SECRET", ""),
+		EnableGithub:  parseBool(getEnv("GITHUB_ENABLED", "false")),
+		InstallID:     parseInt(getEnv("GITHUB_INSTALL_ID", "0")),
+		KeyFile:       getEnv("GITHUB_KEY_FILE", "private-key.pem"),
+		WebhookSecret: getEnv("GITHUB_WEBHOOK_SECRET", ""),
+		ListenAddress: getEnv("LISTEN_ADDRESS", ":8080"),
+		LogFormat:     getEnv("LOG_FORMAT", "text"),
+		LogLevel:      getEnv("LOG_LEVEL", "debug"),
 		Kafka:         kafka.DefaultConfig(),
 		S3: S3{
-			Endpoint:       "localhost:9000",
-			AccessKey:      os.Getenv("S3_ACCESS_KEY"),
-			SecretKey:      os.Getenv("S3_SECRET_KEY"),
-			BucketName:     "deployments.nais.io",
-			BucketLocation: "",
-			UseTLS:         true,
+			Endpoint:       getEnv("S3_ENDPOINT", "localhost:9000"),
+			AccessKey:      getEnv("S3_ACCESS_KEY", "accesskey"),
+			SecretKey:      getEnv("S3_SECRET_KEY", "secretkey"),
+			BucketName:     getEnv("S3_BUCKET_NAME", "deployments.nais.io"),
+			BucketLocation: getEnv("S3_BUCKET_LOCATION", ""),
+			UseTLS:         parseBool(getEnv("S3_SECURE", "false")),
 		},
-		ClientID:     os.Getenv("GITHUB_CLIENT_ID"),
-		ClientSecret: os.Getenv("GITHUB_CLIENT_SECRET"),
-		MetricsPath:  "/metrics",
+		MetricsPath: getEnv("METRICS_PATH", "/metrics"),
 	}
 }

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -17,7 +17,7 @@ type S3 struct {
 }
 
 type Github struct {
-	EnableGithub  bool
+	Enabled       bool
 	ClientID      string
 	ClientSecret  string
 	WebhookSecret string
@@ -62,10 +62,10 @@ func DefaultConfig() *Config {
 		LogLevel:      getEnv("LOG_LEVEL", "debug"),
 		Kafka:         kafka.DefaultConfig(),
 		Github: Github{
-			EnableGithub:  parseBool(getEnv("GITHUB_ENABLED", "false")),
 			ApplicationID: parseInt(getEnv("GITHUB_APP_ID", "0")),
 			ClientID:      getEnv("GITHUB_CLIENT_ID", ""),
 			ClientSecret:  getEnv("GITHUB_CLIENT_SECRET", ""),
+			Enabled:       parseBool(getEnv("GITHUB_ENABLED", "false")),
 			InstallID:     parseInt(getEnv("GITHUB_INSTALL_ID", "0")),
 			KeyFile:       getEnv("GITHUB_KEY_FILE", "private-key.pem"),
 			WebhookSecret: getEnv("GITHUB_WEBHOOK_SECRET", ""),

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -16,20 +16,24 @@ type S3 struct {
 	UseTLS         bool
 }
 
-type Config struct {
+type Github struct {
 	EnableGithub  bool
-	ListenAddress string
-	LogFormat     string
-	LogLevel      string
-	BaseURL       string
+	ClientID      string
+	ClientSecret  string
 	WebhookSecret string
 	ApplicationID int
 	InstallID     int
 	KeyFile       string
+}
+
+type Config struct {
+	ListenAddress string
+	LogFormat     string
+	LogLevel      string
+	BaseURL       string
 	Kafka         kafka.Config
 	S3            S3
-	ClientID      string
-	ClientSecret  string
+	Github        Github
 	MetricsPath   string
 }
 
@@ -53,17 +57,19 @@ func parseInt(str string) int {
 func DefaultConfig() *Config {
 	return &Config{
 		BaseURL:       getEnv("BASE_URL", "http://localhost:8080"),
-		ApplicationID: parseInt(getEnv("GITHUB_APP_ID", "0")),
-		ClientID:      getEnv("GITHUB_CLIENT_ID", ""),
-		ClientSecret:  getEnv("GITHUB_CLIENT_SECRET", ""),
-		EnableGithub:  parseBool(getEnv("GITHUB_ENABLED", "false")),
-		InstallID:     parseInt(getEnv("GITHUB_INSTALL_ID", "0")),
-		KeyFile:       getEnv("GITHUB_KEY_FILE", "private-key.pem"),
-		WebhookSecret: getEnv("GITHUB_WEBHOOK_SECRET", ""),
 		ListenAddress: getEnv("LISTEN_ADDRESS", ":8080"),
 		LogFormat:     getEnv("LOG_FORMAT", "text"),
 		LogLevel:      getEnv("LOG_LEVEL", "debug"),
 		Kafka:         kafka.DefaultConfig(),
+		Github: Github{
+			EnableGithub:  parseBool(getEnv("GITHUB_ENABLED", "false")),
+			ApplicationID: parseInt(getEnv("GITHUB_APP_ID", "0")),
+			ClientID:      getEnv("GITHUB_CLIENT_ID", ""),
+			ClientSecret:  getEnv("GITHUB_CLIENT_SECRET", ""),
+			InstallID:     parseInt(getEnv("GITHUB_INSTALL_ID", "0")),
+			KeyFile:       getEnv("GITHUB_KEY_FILE", "private-key.pem"),
+			WebhookSecret: getEnv("GITHUB_WEBHOOK_SECRET", ""),
+		},
 		S3: S3{
 			Endpoint:       getEnv("S3_ENDPOINT", "localhost:9000"),
 			AccessKey:      getEnv("S3_ACCESS_KEY", "accesskey"),


### PR DESCRIPTION
In this patch:

* give all options their own environment variable equivalent
* change default values to `--github-enabled=false` and `--listen-address=127.0.0.1:8080` to ease development
* related code refactoring