### PR TITLE
Repository list optimization

### DIFF
--- a/hookd/assets/js/site.js
+++ b/hookd/assets/js/site.js
@@ -39,7 +39,7 @@ const app = new Vue({
             return this.showTeams && this.selectedTeams.length > 0
         },
         showErrors() {
-            return this.errors.length > 0 && this.showTeams
+            return this.errors.length > 0 && (this.showTeams || (!this.loading && this.search === ""))
         },
         noResult() {
             return !this.loading && this.search !== "" && this.filteredList.length === 0
@@ -71,6 +71,7 @@ const app = new Vue({
                     this.errors.push("You don't have the sufficient access to any repo, please check your permissions")
                 }
             }).catch((error) => {
+                this.loading = false
                 this.errors.push("An error occurred when fetching repositories, please logout and sign back in.")
                 this.errors.push(error)
             })
@@ -93,6 +94,7 @@ const app = new Vue({
                 }
                 this.teamList = response.data
             }).catch((error) => {
+                this.loading = false
                 this.errors.push("Failed to access teams for " + repository + ". Error " + error)
             })
 

--- a/hookd/pkg/auth/proxy.go
+++ b/hookd/pkg/auth/proxy.go
@@ -70,11 +70,13 @@ func (h *RepositoriesProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	sort.Slice(allRepos, func(i, j int) bool {
-		return strings.ToLower(allRepos[i].Name) < strings.ToLower(allRepos[j].Name)
+	adminRepos := github.FilterRepositoriesByAdmin(allRepos)
+
+	sort.Slice(adminRepos, func(i, j int) bool {
+		return strings.ToLower(adminRepos[i].Name) < strings.ToLower(adminRepos[j].Name)
 	})
 
-	json, err := json.Marshal(allRepos)
+	json, err := json.Marshal(adminRepos)
 
 	if err != nil {
 		log.Error(err)

--- a/hookd/pkg/github/repository.go
+++ b/hookd/pkg/github/repository.go
@@ -2,54 +2,99 @@ package github
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
 	"github.com/prometheus/common/log"
 	"github.com/shurcooL/githubv4"
 )
 
-type repo struct {
-	Name                string `json:"name"`
-	NameWithOwner       string `json:"full_name"`
-	ViewerCanAdminister bool
+var (
+	repositories Repositories
+)
+
+type Repositories struct {
+	sync.RWMutex
+	List          []repo
+	lastCreatedAt time.Time
 }
 
-func GetRepositories(client *githubv4.Client) (allRepos []repo, err error) {
+type repo struct {
+	Name                string    `json:"name"`
+	NameWithOwner       string    `json:"full_name"`
+	ViewerCanAdminister bool      `json:"-"`
+	CreatedAt           time.Time `json:"-"`
+}
+
+func GetRepositories(client *githubv4.Client) (repos []repo, err error) {
 	var query struct {
 		Organization struct {
 			Repositories struct {
 				Nodes      []repo
-				TotalCount githubv4.Int
+				TotalCount int
 
 				PageInfo struct {
 					EndCursor   githubv4.String
 					HasNextPage bool
 				}
-			} `graphql:"repositories(first:100, after: $repositoriesCursor)"`
+			} `graphql:"repositories(first:100, after: $repositoriesCursor, orderBy: {field: $field, direction:$dir})"`
 		} `graphql:"organization(login: $organization)"`
 	}
 
 	variables := map[string]interface{}{
 		"organization":       githubv4.String("navikt"),
 		"repositoriesCursor": (*githubv4.String)(nil),
+		"field":              githubv4.RepositoryOrderFieldCreatedAt,
+		"dir":                githubv4.OrderDirectionDesc,
 	}
 
+Loop:
 	for {
 		err = client.Query(context.Background(), &query, variables)
 		if err != nil {
 			log.Error(err)
-			return
+			return repos, err
 		}
 
+		repositories.RLock()
 		for _, repo := range query.Organization.Repositories.Nodes {
-			if repo.ViewerCanAdminister {
-				allRepos = append(allRepos, repo)
+			if repo.CreatedAt.After(repositories.lastCreatedAt) {
+				repos = append(repos, repo)
+			} else {
+				repositories.RUnlock()
+				break Loop
 			}
 		}
+		repositories.RUnlock()
 
 		if !query.Organization.Repositories.PageInfo.HasNextPage {
 			break
 		}
 		variables["repositoriesCursor"] = githubv4.NewString(query.Organization.Repositories.PageInfo.EndCursor)
+	}
+
+	repositories.Lock()
+	defer repositories.Unlock()
+
+	allRepos := append(repos, repositories.List...)
+	if len(allRepos) != 0 && len(allRepos) == query.Organization.Repositories.TotalCount {
+		repositories.lastCreatedAt = allRepos[0].CreatedAt
+		repositories.List = allRepos
+	} else {
+		repositories.lastCreatedAt = time.Time{}
+		repositories.List = []repo{}
+		return repositories.List, fmt.Errorf("fetching new repositories, count mismatch")
+	}
+
+	return repositories.List, nil
+}
+
+func FilterRepositoriesByAdmin(allRepos []repo) (filteredRepos []repo) {
+	for _, repo := range allRepos {
+		if repo.ViewerCanAdminister {
+			filteredRepos = append(filteredRepos, repo)
+		}
 	}
 	return
 }


### PR DESCRIPTION
Following the graphQL optimizations I've created a struct for holding all of the repositories, caching them and only adding onto the list once new ones are added. 

This reduces the graphQL query to almost always be just one query, except for the first time after the app starts or an repository is deleted.

This code scales a lot better as we get more and more repositories and reduces the amount of request we perform towards the github API. It's also concurrent and tolerant of different failure scenarios. Where the worst outcome is just that you have to get all of the repositories one more time.

I split out the admin filtering functionality from the get repositories code, so the GetRepositories function is as clean as possible.

The GetRepositories function is definitely more complicated with the label breaks and the mutex logic, but I tried to keep it to a minimum, while still making the code effective.

I also did some small frontend optimizations/ bugfixes that appeared during testing of this new feature.

I've tested it extensively and it seems good to me.

Feedback is very welcome! 