### PR TITLE
GCP support

### DIFF
--- a/cmd/deployd/main.go
+++ b/cmd/deployd/main.go
@@ -27,6 +27,8 @@ func init() {
 	flag.StringVar(&cfg.Cluster, "cluster", cfg.Cluster, "Apply changes only within this cluster.")
 	flag.StringVar(&cfg.MetricsListenAddr, "metrics-listen-addr", cfg.MetricsListenAddr, "Serve metrics on this address.")
 	flag.StringVar(&cfg.MetricsPath, "metrics-path", cfg.MetricsPath, "Serve metrics on this endpoint.")
+	flag.BoolVar(&cfg.TeamNamespaces, "team-namespaces", cfg.TeamNamespaces, "Set to true if team service accounts live in team's own namespace.")
+	flag.BoolVar(&cfg.AutoCreateServiceAccount, "auto-create-service-account", cfg.AutoCreateServiceAccount, "Set to true to automatically create service accounts.")
 
 	kafka.SetupFlags(&cfg.Kafka)
 }
@@ -90,7 +92,7 @@ func run() error {
 			logger := kafka.ConsumerMessageLogger(&m)
 
 			// Check the validity and authenticity of the message.
-			deployd.Run(&logger, m.Value, client.SignatureKey, cfg.Cluster, kube, statusChan)
+			deployd.Run(&logger, m.Value, client.SignatureKey, *cfg, kube, statusChan)
 
 		case status := <-statusChan:
 			logger := log.WithFields(status.LogFields())

--- a/deployd/pkg/config/config.go
+++ b/deployd/pkg/config/config.go
@@ -5,21 +5,25 @@ import (
 )
 
 type Config struct {
-	LogFormat         string
-	LogLevel          string
-	Cluster           string
-	MetricsListenAddr string
-	MetricsPath       string
-	Kafka             kafka.Config
+	LogFormat                string
+	LogLevel                 string
+	Cluster                  string
+	MetricsListenAddr        string
+	MetricsPath              string
+	TeamNamespaces           bool
+	AutoCreateServiceAccount bool
+	Kafka                    kafka.Config
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		LogFormat:         "text",
-		LogLevel:          "debug",
-		Cluster:           "local",
-		MetricsListenAddr: "127.0.0.1:8081",
-		MetricsPath:       "/metrics",
-		Kafka:             kafka.DefaultConfig(),
+		LogFormat:                "text",
+		LogLevel:                 "debug",
+		Cluster:                  "local",
+		MetricsListenAddr:        "127.0.0.1:8081",
+		MetricsPath:              "/metrics",
+		TeamNamespaces:           false,
+		AutoCreateServiceAccount: true,
+		Kafka:                    kafka.DefaultConfig(),
 	}
 }

--- a/deployd/pkg/deployd/deployd.go
+++ b/deployd/pkg/deployd/deployd.go
@@ -19,6 +19,10 @@ var (
 	deploymentTimeout = time.Second * 300
 )
 
+const (
+	DefaultTeamclientNamespace = "default"
+)
+
 func matchesCluster(req deployment.DeploymentRequest, cluster string) error {
 	if req.GetCluster() != cluster {
 		return ErrNotMyCluster
@@ -100,7 +104,7 @@ func Run(logger *log.Entry, msg []byte, key, cluster string, kube kubeclient.Tea
 	p := req.GetPayloadSpec()
 	logger.Data["team"] = p.Team
 
-	teamClient, err := kube.TeamClient(p.Team)
+	teamClient, err := kube.TeamClient(p.Team, DefaultTeamclientNamespace)
 	if err != nil {
 		deployStatus <- deployment.NewErrorStatus(*req, err)
 		return

--- a/deployd/pkg/deployd/deployd.go
+++ b/deployd/pkg/deployd/deployd.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/navikt/deployment/common/pkg/deployment"
+	"github.com/navikt/deployment/deployd/pkg/config"
 	"github.com/navikt/deployment/deployd/pkg/kubeclient"
 	"github.com/navikt/deployment/deployd/pkg/metrics"
 	log "github.com/sirupsen/logrus"
@@ -85,9 +86,11 @@ func Prepare(msg []byte, key, cluster string) (*deployment.DeploymentRequest, er
 	return req, nil
 }
 
-func Run(logger *log.Entry, msg []byte, key, cluster string, kube kubeclient.TeamClientProvider, deployStatus chan *deployment.DeploymentStatus) {
+func Run(logger *log.Entry, msg []byte, key string, cfg config.Config, kube kubeclient.TeamClientProvider, deployStatus chan *deployment.DeploymentStatus) {
+	var namespace string
+
 	// Check the validity and authenticity of the message.
-	req, err := Prepare(msg, key, cluster)
+	req, err := Prepare(msg, key, cfg.Cluster)
 	if req != nil {
 		nl := logger.WithFields(req.LogFields())
 		logger.Data = nl.Data // propagate changes down to caller
@@ -104,7 +107,13 @@ func Run(logger *log.Entry, msg []byte, key, cluster string, kube kubeclient.Tea
 	p := req.GetPayloadSpec()
 	logger.Data["team"] = p.Team
 
-	teamClient, err := kube.TeamClient(p.Team, DefaultTeamclientNamespace)
+	if cfg.TeamNamespaces {
+		namespace = p.Team
+	} else {
+		namespace = DefaultTeamclientNamespace
+	}
+
+	teamClient, err := kube.TeamClient(p.Team, namespace, cfg.AutoCreateServiceAccount)
 	if err != nil {
 		deployStatus <- deployment.NewErrorStatus(*req, err)
 		return

--- a/deployd/pkg/kubeclient/main.go
+++ b/deployd/pkg/kubeclient/main.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	Namespace           = "default"
 	ServiceUserTemplate = "serviceuser-%s"
 	ClusterName         = "kubernetes"
 )
@@ -35,7 +34,7 @@ type Client struct {
 }
 
 type TeamClientProvider interface {
-	TeamClient(team string) (TeamClient, error)
+	TeamClient(team, namespace string) (TeamClient, error)
 }
 
 func New() (*Client, error) {
@@ -55,7 +54,7 @@ func New() (*Client, error) {
 	}, nil
 }
 
-func (c *Client) teamConfig(team string) (*clientcmdapi.Config, error) {
+func (c *Client) teamConfig(team, namespace string) (*clientcmdapi.Config, error) {
 	serviceAccountName := serviceAccountName(team)
 
 	// Get service account for this team. If it does not exist, create it.
@@ -64,14 +63,14 @@ func (c *Client) teamConfig(team string) (*clientcmdapi.Config, error) {
 	//
 	// Kubernetes needs some time to generate the service account token,
 	// so we insert a small pause to wait for it.
-	_, err := createServiceAccount(c.Base, serviceAccountName)
+	_, err := createServiceAccount(c.Base, serviceAccountName, namespace)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("while generating service account: %s", err)
 	} else if err == nil {
 		time.Sleep(tokenGenerationTimeout)
 	}
 
-	serviceAccount, err := serviceAccount(c.Base, serviceAccountName)
+	serviceAccount, err := serviceAccount(c.Base, serviceAccountName, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("while retrieving service account: %s", err)
 	}
@@ -93,7 +92,7 @@ func (c *Client) teamConfig(team string) (*clientcmdapi.Config, error) {
 		CertificateAuthorityData: c.Config.CAData,
 	}
 	teamConfig.Contexts[ClusterName] = &clientcmdapi.Context{
-		Namespace: Namespace,
+		Namespace: namespace,
 		AuthInfo:  serviceAccountName,
 		Cluster:   ClusterName,
 	}
@@ -104,8 +103,8 @@ func (c *Client) teamConfig(team string) (*clientcmdapi.Config, error) {
 
 // TeamClient returns a Kubernetes REST client tailored for a specific team.
 // The user is the `serviceuser-TEAM` in the `default` namespace.
-func (c *Client) TeamClient(team string) (TeamClient, error) {
-	config, err := c.teamConfig(team)
+func (c *Client) TeamClient(team, namespace string) (TeamClient, error) {
+	config, err := c.teamConfig(team, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -159,9 +158,9 @@ func serviceAccountName(team string) string {
 	return fmt.Sprintf(ServiceUserTemplate, team)
 }
 
-func serviceAccount(client kubernetes.Interface, serviceAccountName string) (*v1.ServiceAccount, error) {
-	log.Tracef("Attempting to retrieve service account '%s' in namespace %s", serviceAccountName, Namespace)
-	return client.CoreV1().ServiceAccounts(Namespace).Get(serviceAccountName, metav1.GetOptions{})
+func serviceAccount(client kubernetes.Interface, serviceAccountName, namespace string) (*v1.ServiceAccount, error) {
+	log.Tracef("Attempting to retrieve service account '%s' in namespace %s", serviceAccountName, namespace)
+	return client.CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, metav1.GetOptions{})
 }
 
 func serviceAccountSecret(client kubernetes.Interface, serviceAccount v1.ServiceAccount) (*v1.Secret, error) {
@@ -169,19 +168,19 @@ func serviceAccountSecret(client kubernetes.Interface, serviceAccount v1.Service
 		return nil, fmt.Errorf("no secret associated with service account '%s'", serviceAccount.Name)
 	}
 	secretRef := serviceAccount.Secrets[0]
-	log.Tracef("Attempting to retrieve secret '%s' in namespace %s", secretRef.Name, Namespace)
-	return client.CoreV1().Secrets(Namespace).Get(secretRef.Name, metav1.GetOptions{})
+	log.Tracef("Attempting to retrieve secret '%s' in namespace %s", secretRef.Name, serviceAccount.Namespace)
+	return client.CoreV1().Secrets(serviceAccount.Namespace).Get(secretRef.Name, metav1.GetOptions{})
 }
 
-func createServiceAccount(client kubernetes.Interface, serviceAccountName string) (*v1.ServiceAccount, error) {
-	log.Tracef("Attempting to create service account '%s' in namespace %s", serviceAccountName, Namespace)
+func createServiceAccount(client kubernetes.Interface, serviceAccountName, namespace string) (*v1.ServiceAccount, error) {
+	log.Tracef("Attempting to create service account '%s' in namespace %s", serviceAccountName, namespace)
 	serviceAccount := v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
-			Namespace: Namespace,
+			Namespace: namespace,
 		},
 	}
-	return client.CoreV1().ServiceAccounts(Namespace).Create(&serviceAccount)
+	return client.CoreV1().ServiceAccounts(namespace).Create(&serviceAccount)
 }
 
 func authInfo(secret v1.Secret) clientcmdapi.AuthInfo {


### PR DESCRIPTION
This patch adds options for using team namespace service accounts, and disabling automatic creation of service accounts.

```
--team-namespaces               Set to true if team service accounts live in team's own namespace.
--auto-create-service-account   Set to true to automatically create service accounts. (default true)
```

In GCP these need to be set:

```
--team-namespaces=true --auto-create-service-account=false
```