### PR TITLE
Use Vault as backend for team API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,19 @@ Used as a configuration backend. Information about repository team access is sto
 Check out the repository and run `make`. Dependencies will download automatically, and you should have three binary files at `hookd/hookd`, `deployd/deployd` and `token-generator`.
 
 ### External dependencies
-Start the external dependencies by running `docker-compose up`. This will start local Kafka and S3 servers.
+Start the external dependencies by running `docker-compose up`. This will start local Kafka, S3, and Vault servers.
 
 The S3 access and secret keys are `accesskey` and `secretkey` respectively. Conveniently, these are
 the default options for _hookd_ as well, so you don't have to configure anything.
+
+### Vault
+The `/api/v1/deploy` endpoint uses Hashicorp Vault to store teams' API keys. To make this work, set up a Vault KV store version 1
+on the server specified by `--vault-address` and on the path specified by `--vault-path`.
+
+For instance, with the default values of `--vault-address=http://localhost:8080 --vault-path=/v1/apikey/nais-deploy --vault-key=key`:
+
+* Set up `/apikey` as a KV v1 store.
+* Create secrets under `/apikey/nais-deploy/<team>` with key `key` and the pre-shared secret as the value.
 
 ### token-generator
 * Set up a google cloud storage bucket

--- a/README.md
+++ b/README.md
@@ -70,11 +70,8 @@ The code can be derived by hashing the request body using the SHA256 algorithm t
 ```json
 {
   "githubDeployment": { ... },
-  "correlationID": "",
-  "message": "successful deployment",
-	GithubDeployment *gh.Deployment `json:"githubDeployment,omitempty"`
-	CorrelationID    string         `json:"correlationID,omitempty"`
-	Message          string         `json:"message,omitempty"`
+  "correlationID": "9a0d1702-e7c5-448f-8a90-1e5ee29a043b",
+  "message": "successful deployment"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ to track the status of your deployment.
 Additionally, the header `X-NAIS-Signature` must contain a keyed-hash message authentication code (HMAC).
 The code can be derived by hashing the request body using the SHA256 algorithm together with your team's NAIS Deploy API key.
 
-#### Request headers
-
-| Field | Type | Description |
-|-------|------|-------------|
 #### Response specification
 
 ```json

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -53,8 +54,8 @@ func init() {
 	flag.StringVar(&cfg.Vault.Path, "vault-path", cfg.Vault.Path, "Base path to Vault KV API key store.")
 	flag.StringVar(&cfg.Vault.Address, "vault-address", cfg.Vault.Address, "Address to Vault server.")
 	flag.StringVar(&cfg.Vault.KeyName, "vault-key-name", cfg.Vault.KeyName, "API keys are stored in this key.")
-	flag.StringVar(&cfg.Vault.TokenFile, "vault-token-file", cfg.Vault.TokenFile, "Vault JWT retrieved from this file.")
-	flag.StringVar(&cfg.Vault.Token, "vault-token", cfg.Vault.Token, "Vault JWT (overrides --vault-token-file).")
+	flag.StringVar(&cfg.Vault.TokenFile, "vault-token-file", cfg.Vault.TokenFile, "Vault JWT retrieved from this file (overrides --vault-token).")
+	flag.StringVar(&cfg.Vault.Token, "vault-token", cfg.Vault.Token, "Vault JWT.")
 
 	kafka.SetupFlags(&cfg.Kafka)
 }
@@ -107,6 +108,14 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("cannot instantiate Github installation client: %s", err)
 		}
+	}
+
+	if len(cfg.Vault.TokenFile) > 0 {
+		tok, err := ioutil.ReadFile(cfg.Vault.TokenFile)
+		if err != nil {
+			return fmt.Errorf("read Vault token file: %s", err)
+		}
+		cfg.Vault.Token = string(tok)
 	}
 
 	requestChan := make(chan deployment.DeploymentRequest, queueSize)

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -130,10 +130,11 @@ func run() error {
 		DeploymentStatus:  statusChan,
 		GithubClient:      githubClient,
 		APIKeyStorage: &persistence.VaultApiKeyStorage{
-			Address: cfg.Vault.Address,
-			Path:    cfg.Vault.Path,
-			KeyName: cfg.Vault.KeyName,
-			Token:   cfg.Vault.Token,
+			Address:    cfg.Vault.Address,
+			Path:       cfg.Vault.Path,
+			KeyName:    cfg.Vault.KeyName,
+			Token:      cfg.Vault.Token,
+			HttpClient: http.DefaultClient,
 		},
 	}
 

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -102,12 +102,16 @@ func run() error {
 	go kafkaClient.ConsumerLoop()
 
 	var installationClient *gh.Client
+	var githubClient github.Client
 
 	if cfg.Github.Enabled {
 		installationClient, err = github.InstallationClient(cfg.Github.ApplicationID, cfg.Github.InstallID, cfg.Github.KeyFile)
 		if err != nil {
 			return fmt.Errorf("cannot instantiate Github installation client: %s", err)
 		}
+		githubClient = github.New(installationClient)
+	} else {
+		githubClient = github.FakeClient()
 	}
 
 	if len(cfg.Vault.TokenFile) > 0 {
@@ -125,7 +129,7 @@ func run() error {
 		DeploymentRequest: requestChan,
 		DeploymentStatus:  statusChan,
 		APIKeyStorage:     &persistence.StaticKeyApiKeyStorage{},
-		GithubClient:      github.New(installationClient),
+		GithubClient:      githubClient,
 	}
 
 	githubDeploymentHandler := &server.GithubDeploymentHandler{

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -50,6 +50,12 @@ func init() {
 	flag.StringVar(&cfg.S3.BucketLocation, "s3-bucket-location", cfg.S3.BucketLocation, "S3 bucket location.")
 	flag.BoolVar(&cfg.S3.UseTLS, "s3-secure", cfg.S3.UseTLS, "Use TLS for S3 connections.")
 
+	flag.StringVar(&cfg.Vault.Path, "vault-path", cfg.Vault.Path, "Base path to Vault KV API key store.")
+	flag.StringVar(&cfg.Vault.Address, "vault-address", cfg.Vault.Address, "Address to Vault server.")
+	flag.StringVar(&cfg.Vault.KeyName, "vault-key-name", cfg.Vault.KeyName, "API keys are stored in this key.")
+	flag.StringVar(&cfg.Vault.TokenFile, "vault-token-file", cfg.Vault.TokenFile, "Vault JWT retrieved from this file.")
+	flag.StringVar(&cfg.Vault.Token, "vault-token", cfg.Vault.Token, "Vault JWT (overrides --vault-token-file).")
+
 	kafka.SetupFlags(&cfg.Kafka)
 }
 

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -144,8 +144,6 @@ func run() error {
 		TeamRepositoryStorage: teamRepositoryStorage,
 	}
 
-	// FIXME: feature switched off
-	//_ = deploymentHandler
 	http.Handle("/api/v1/deploy", deploymentHandler)
 
 	http.Handle("/events", githubDeploymentHandler)

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -128,8 +128,13 @@ func run() error {
 	deploymentHandler := &server.DeploymentHandler{
 		DeploymentRequest: requestChan,
 		DeploymentStatus:  statusChan,
-		APIKeyStorage:     &persistence.StaticKeyApiKeyStorage{},
 		GithubClient:      githubClient,
+		APIKeyStorage: &persistence.VaultApiKeyStorage{
+			Address: cfg.Vault.Address,
+			Path:    cfg.Vault.Path,
+			KeyName: cfg.Vault.KeyName,
+			Token:   cfg.Vault.Token,
+		},
 	}
 
 	githubDeploymentHandler := &server.GithubDeploymentHandler{
@@ -140,8 +145,8 @@ func run() error {
 	}
 
 	// FIXME: feature switched off
-	_ = deploymentHandler
-	// http.Handle("/api/v1/deploy", deploymentHandler)
+	//_ = deploymentHandler
+	http.Handle("/api/v1/deploy", deploymentHandler)
 
 	http.Handle("/events", githubDeploymentHandler)
 	http.Handle("/auth/login", &auth.LoginHandler{

--- a/cmd/mkdeploy/main.go
+++ b/cmd/mkdeploy/main.go
@@ -38,7 +38,7 @@ func DefaultConfig() Config {
 		Ref:        "master",
 		Owner:      "navikt",
 		Repository: "deployment",
-		Payload:    "[]",
+		Payload:    "[{}]",
 		Cluster:    "local",
 	}
 }

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -91,7 +91,7 @@ func DefaultConfig() *Config {
 			TokenFile: getEnv("VAULT_TOKEN_FILE", ""),
 			Address:   getEnv("VAULT_ADDRESS", "http://localhost:8200"),
 			KeyName:   getEnv("VAULT_KEY_NAME", "key"),
-			Path:      getEnv("VAULT_PATH", "/apikey/nais-deploy"),
+			Path:      getEnv("VAULT_PATH", "/v1/apikey/nais-deploy"),
 			Token:     getEnv("VAULT_TOKEN", ""),
 		},
 		MetricsPath: getEnv("METRICS_PATH", "/metrics"),

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -16,6 +16,14 @@ type S3 struct {
 	UseTLS         bool   `json:"secure"`
 }
 
+type Vault struct {
+	TokenFile string
+	Token     string
+	Address   string
+	Path      string
+	KeyName   string
+}
+
 type Github struct {
 	Enabled       bool
 	ClientID      string
@@ -34,6 +42,7 @@ type Config struct {
 	Kafka         kafka.Config
 	S3            S3
 	Github        Github
+	Vault         Vault
 	MetricsPath   string
 }
 
@@ -77,6 +86,13 @@ func DefaultConfig() *Config {
 			BucketName:     getEnv("S3_BUCKET_NAME", "deployments.nais.io"),
 			BucketLocation: getEnv("S3_BUCKET_LOCATION", ""),
 			UseTLS:         parseBool(getEnv("S3_SECURE", "false")),
+		},
+		Vault: Vault{
+			TokenFile: getEnv("VAULT_TOKEN_FILE", ""),
+			Address:   getEnv("VAULT_ADDRESS", "http://localhost:8200"),
+			KeyName:   getEnv("VAULT_KEY_NAME", "key"),
+			Path:      getEnv("VAULT_PATH", "/apikey/nais-deploy"),
+			Token:     getEnv("VAULT_TOKEN", ""),
 		},
 		MetricsPath: getEnv("METRICS_PATH", "/metrics"),
 	}

--- a/hookd/pkg/config/config.go
+++ b/hookd/pkg/config/config.go
@@ -92,7 +92,7 @@ func DefaultConfig() *Config {
 			Address:   getEnv("VAULT_ADDRESS", "http://localhost:8200"),
 			KeyName:   getEnv("VAULT_KEY_NAME", "key"),
 			Path:      getEnv("VAULT_PATH", "/v1/apikey/nais-deploy"),
-			Token:     getEnv("VAULT_TOKEN", ""),
+			Token:     getEnv("VAULT_TOKEN", "123456789"),
 		},
 		MetricsPath: getEnv("METRICS_PATH", "/metrics"),
 	}

--- a/hookd/pkg/github/deployment.go
+++ b/hookd/pkg/github/deployment.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 
 	gh "github.com/google/go-github/v27/github"
 )
@@ -23,4 +24,14 @@ func New(c *gh.Client) Client {
 func (c *client) CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error) {
 	deployment, _, err := c.client.Repositories.CreateDeployment(ctx, owner, repository, request)
 	return deployment, err
+}
+
+type fakeClient struct{}
+
+func FakeClient() Client {
+	return &fakeClient{}
+}
+
+func (c *fakeClient) CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error) {
+	return nil, fmt.Errorf("GitHub requests are not enabled")
 }

--- a/hookd/pkg/persistence/apikey.go
+++ b/hookd/pkg/persistence/apikey.go
@@ -1,7 +1,11 @@
 package persistence
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
+	"path"
 )
 
 var (
@@ -17,14 +21,64 @@ type ApiKeyStorage interface {
 	IsErrNotFound(err error) bool
 }
 
+type VaultApiKeyStorage struct {
+	Address    string
+	Path       string
+	KeyName    string
+	Token      string
+	HttpClient *http.Client
+}
+
+type VaultResponse struct {
+	Data map[string]string `json:"data"`
+}
+
+func (s *VaultApiKeyStorage) Read(team string) ([]byte, error) {
+	u, err := url.Parse(s.Address)
+	u.Path = path.Join(s.Path, team)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct URL to vault: %s", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to create HTTP request: %s", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.Token))
+
+	resp, err := s.HttpClient.Do(req)
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to get key from Vault: %s", err)
+	}
+
+	var vaultResp VaultResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&vaultResp); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response from vault: %s", err)
+	}
+
+	return []byte(vaultResp.Data[s.KeyName]), err
+}
+func (s *VaultApiKeyStorage) IsErrNotFound(err error) bool {
+	return err == ErrNotFound
+}
+
 type StaticKeyApiKeyStorage struct {
 	Key []byte
 }
 
-func (a *StaticKeyApiKeyStorage) Read(team string) ([]byte, error) {
-	return a.Key, nil
+func (s *StaticKeyApiKeyStorage) Read(team string) ([]byte, error) {
+	return s.Key, nil
 }
 
-func (a *StaticKeyApiKeyStorage) IsErrNotFound(err error) bool {
+func (s *StaticKeyApiKeyStorage) IsErrNotFound(err error) bool {
 	return true
 }

--- a/hookd/pkg/persistence/apikey_test.go
+++ b/hookd/pkg/persistence/apikey_test.go
@@ -1,17 +1,76 @@
 package persistence_test
 
-//import (
-//	"github.com/navikt/deployment/hookd/pkg/persistence"
-//	"net/http/httptest"
-//	"testing"
-//)
-//
-//func TestVaultApiKeyStorage(t *testing.T) {
-//	//x := httptest.NewServer(nil)
-//	//client := x.Client()
-//	vault := persistence.VaultApiKeyStorage{
-//		HttpClient:
-//	}
-//
-//	vault.Read()
-//}
+import (
+	"fmt"
+	"github.com/navikt/deployment/hookd/pkg/config"
+	"github.com/navikt/deployment/hookd/pkg/persistence"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const (
+	Existing    = "existing"
+	Unavailable = "unavailable"
+	Nonexistent = "nonexistent"
+	ApiKey      = "topsecret"
+)
+
+func TestVaultApiKeyStorage(t *testing.T) {
+	defaults := config.DefaultConfig().Vault
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch teamname(r.URL) {
+		case Existing:
+			_, _ = io.WriteString(w,
+				fmt.Sprintf(`{
+                    "data": {
+                      "key": "%s"
+                    }
+                 }`, ApiKey))
+		case Nonexistent:
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte("not found"))
+		case Unavailable:
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("internal server error"))
+		default:
+			panic("we should not be here")
+		}
+	}))
+
+	defer server.Close()
+
+	vault := persistence.VaultApiKeyStorage{
+		HttpClient: server.Client(),
+		Address:    server.URL,
+		Path:       defaults.Path,
+		KeyName:    defaults.KeyName,
+		Token:      defaults.Token,
+	}
+
+	t.Run("finds api keys in vault", func(t *testing.T) {
+		apiKey, err := vault.Read(Existing)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(ApiKey), apiKey)
+	})
+
+	t.Run("fails when team doesnt exist", func(t *testing.T) {
+		_, err := vault.Read(Nonexistent)
+		assert.Error(t, err)
+		assert.True(t, vault.IsErrNotFound(err))
+	})
+
+	t.Run("returns an error when communication with vault fails somehow", func(t *testing.T) {
+		_, err := vault.Read(Unavailable)
+		assert.Error(t, err)
+	})
+}
+
+func teamname(u *url.URL) string {
+	fragments := strings.Split(u.Path, "/")
+	return fragments[len(fragments)-1]
+}

--- a/hookd/pkg/persistence/apikey_test.go
+++ b/hookd/pkg/persistence/apikey_test.go
@@ -28,9 +28,9 @@ func TestVaultApiKeyStorage(t *testing.T) {
 			_, _ = io.WriteString(w,
 				fmt.Sprintf(`{
                     "data": {
-                      "key": "%s"
+                      "%s": "%s"
                     }
-                 }`, ApiKey))
+                 }`, defaults.KeyName, ApiKey))
 		case Nonexistent:
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("not found"))

--- a/hookd/pkg/persistence/apikey_test.go
+++ b/hookd/pkg/persistence/apikey_test.go
@@ -1,0 +1,17 @@
+package persistence_test
+
+//import (
+//	"github.com/navikt/deployment/hookd/pkg/persistence"
+//	"net/http/httptest"
+//	"testing"
+//)
+//
+//func TestVaultApiKeyStorage(t *testing.T) {
+//	//x := httptest.NewServer(nil)
+//	//client := x.Client()
+//	vault := persistence.VaultApiKeyStorage{
+//		HttpClient:
+//	}
+//
+//	vault.Read()
+//}

--- a/hookd/pkg/server/handler.go
+++ b/hookd/pkg/server/handler.go
@@ -155,7 +155,7 @@ func (h *DeploymentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.WriteHeader(http.StatusBadGateway)
-		deploymentResponse.Message = "unable to communicate with api key service"
+		deploymentResponse.Message = "something wrong happened when communicating with api key service"
 		deploymentResponse.render(w)
 		h.log.Errorf("unable to fetch team apikey from storage: %s", err)
 		return

--- a/hookd/pkg/server/testdata/apikey_unavailable.json
+++ b/hookd/pkg/server/testdata/apikey_unavailable.json
@@ -14,7 +14,7 @@
   "response": {
     "statusCode": 502,
     "body": {
-      "message": "unable to communicate with api key service"
+      "message": "something wrong happened when communicating with api key service"
     }
   }
 }


### PR DESCRIPTION
This patch enables native deploys by use of the endpoint `/api/v1/deploy`. Team API keys are retrieved from Hashicorp Vault.