### PR TITLE
Check if teams have GitHub repo access

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The code can be derived by hashing the request body using the SHA256 algorithm t
 |-------|------|-------------|
 | 201 | N/A | The request was valid and will be deployed. Track the status of your deployment using the GitHub Deployments API. |
 | 400 | NO | The request contains errors and cannot be processed. Check the `message` field for details.
-| 403 | MAYBE | Authentication failed. Check that you're supplying the correct `team`, using the correct API key, and properly signing the request. |
+| 403 | MAYBE | Authentication failed. Check that you're supplying the correct `team`; that the team is present on GitHub and has admin access to your repository; that you're using the correct API key; and properly HMAC signing the request. |
 | 404 | NO | Wrong URL. |
 | 5xx | YES | NAIS deploy is having problems and is currently being fixed. Retry later. |
 

--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -32,7 +32,7 @@ var (
 	cfg            = config.DefaultConfig()
 	retryInterval  = time.Second * 5
 	queueSize      = 32
-	requestTimeout = time.Second * 3
+	requestTimeout = time.Second * 10
 )
 
 func init() {

--- a/hookd/pkg/github/deployment.go
+++ b/hookd/pkg/github/deployment.go
@@ -9,6 +9,7 @@ import (
 
 type Client interface {
 	CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error)
+	TeamAllowed(ctx context.Context, owner, repository, team string) (bool, error)
 }
 
 type client struct {
@@ -19,6 +20,23 @@ func New(c *gh.Client) Client {
 	return &client{
 		client: c,
 	}
+}
+
+func (c *client) TeamAllowed(ctx context.Context, owner, repository, teamName string) (bool, error) {
+	team, _, err := c.client.Teams.GetTeamBySlug(ctx, owner, teamName)
+	if err != nil {
+		return false, err
+	}
+
+	repo, _, err := c.client.Teams.IsTeamRepo(ctx, team.GetID(), owner, repository)
+	if err != nil {
+		return false, err
+	}
+	if repo == nil {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (c *client) CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error) {
@@ -34,4 +52,8 @@ func FakeClient() Client {
 
 func (c *fakeClient) CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error) {
 	return nil, fmt.Errorf("GitHub requests are not enabled")
+}
+
+func (c *fakeClient) TeamAllowed(ctx context.Context, owner, repository, team string) (bool, error) {
+	return false, fmt.Errorf("GitHub requests are not enabled")
 }

--- a/hookd/pkg/server/handler_test.go
+++ b/hookd/pkg/server/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	gh "github.com/google/go-github/v27/github"
+	"github.com/navikt/deployment/hookd/pkg/github"
 
 	types "github.com/navikt/deployment/common/pkg/deployment"
 	"github.com/navikt/deployment/hookd/pkg/persistence"
@@ -43,14 +44,14 @@ type testCase struct {
 
 type githubClient struct{}
 
-func (g *githubClient) TeamAllowed(ctx context.Context, owner, repository, teamName string) (bool, error) {
+func (g *githubClient) TeamAllowed(ctx context.Context, owner, repository, teamName string) error {
 	switch teamName {
 	case "team_not_repo_owner":
-		return false, nil
+		return github.ErrTeamNoAccess
 	case "team_not_on_github":
-		return false, fmt.Errorf("team does not manage repository")
+		return github.ErrTeamNotExist
 	default:
-		return true, nil
+		return nil
 	}
 }
 

--- a/hookd/pkg/server/handler_test.go
+++ b/hookd/pkg/server/handler_test.go
@@ -43,6 +43,17 @@ type testCase struct {
 
 type githubClient struct{}
 
+func (g *githubClient) TeamAllowed(ctx context.Context, owner, repository, teamName string) (bool, error) {
+	switch teamName {
+	case "team_not_repo_owner":
+		return false, nil
+	case "team_not_on_github":
+		return false, fmt.Errorf("team does not manage repository")
+	default:
+		return true, nil
+	}
+}
+
 func (g *githubClient) CreateDeployment(ctx context.Context, owner, repository string, request *gh.DeploymentRequest) (*gh.Deployment, error) {
 	switch repository {
 	case "unavailable":

--- a/hookd/pkg/server/testdata/team_not_on_github.json
+++ b/hookd/pkg/server/testdata/team_not_on_github.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "body": {
+      "resources": [
+        {}
+      ],
+      "team": "team_not_on_github",
+      "cluster": "local",
+      "owner": "foo",
+      "repository": "bar",
+      "ref": "master"
+    }
+  },
+  "response": {
+    "statusCode": 502,
+    "body": {
+      "message": "unable to create GitHub deployment"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/team_not_on_github.json
+++ b/hookd/pkg/server/testdata/team_not_on_github.json
@@ -12,9 +12,9 @@
     }
   },
   "response": {
-    "statusCode": 502,
+    "statusCode": 403,
     "body": {
-      "message": "unable to create GitHub deployment"
+      "message": "team does not exist on GitHub"
     }
   }
 }

--- a/hookd/pkg/server/testdata/team_not_repo_owner.json
+++ b/hookd/pkg/server/testdata/team_not_repo_owner.json
@@ -14,7 +14,7 @@
   "response": {
     "statusCode": 403,
     "body": {
-      "message": "team 'team_not_repo_owner' does not manage GitHub repository 'foo/bar'"
+      "message": "team has no admin access to repository"
     }
   }
 }

--- a/hookd/pkg/server/testdata/team_not_repo_owner.json
+++ b/hookd/pkg/server/testdata/team_not_repo_owner.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "body": {
+      "resources": [
+        {}
+      ],
+      "team": "team_not_repo_owner",
+      "cluster": "local",
+      "owner": "foo",
+      "repository": "bar",
+      "ref": "master"
+    }
+  },
+  "response": {
+    "statusCode": 403,
+    "body": {
+      "message": "team 'team_not_repo_owner' does not manage GitHub repository 'foo/bar'"
+    }
+  }
+}


### PR DESCRIPTION
When deploying, check that the team slug is added as a repository admin in order to grant deploy access.