### PR TITLE
Implement /api/v1/status endpoint

### DIFF
--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -155,6 +155,11 @@ func run() error {
 		Clusters:          cfg.Clusters,
 	}
 
+	statusHandler := &server.StatusHandler{
+		GithubClient:      githubClient,
+		APIKeyStorage:     apiKeys,
+	}
+
 	githubDeploymentHandler := &server.GithubDeploymentHandler{
 		DeploymentRequest:     requestChan,
 		DeploymentStatus:      statusChan,
@@ -198,6 +203,7 @@ func run() error {
 			chi_middleware.Timeout(requestTimeout),
 		)
 		r.Post("/deploy", deploymentHandler.ServeHTTP)
+		r.Post("/status", statusHandler.ServeHTTP)
 	})
 
 	// Mount /events for "legacy" GitHub deployment handling

--- a/hookd/pkg/github/deployment.go
+++ b/hookd/pkg/github/deployment.go
@@ -11,6 +11,7 @@ import (
 var (
 	ErrTeamNotExist         = fmt.Errorf("team does not exist on GitHub")
 	ErrTeamNoAccess         = fmt.Errorf("team has no admin access to repository")
+	ErrDeploymentNotFound   = fmt.Errorf("deployment not found")
 	ErrNoDeploymentStatuses = fmt.Errorf("no deployment statuses available")
 	ErrGitHubNotEnabled     = fmt.Errorf("GitHub requests are not enabled")
 )
@@ -60,7 +61,10 @@ func (c *client) DeploymentStatus(ctx context.Context, owner, repository string,
 	opts := &gh.ListOptions{
 		PerPage: 1,
 	}
-	deploy, _, err := c.client.Repositories.ListDeploymentStatuses(ctx, owner, repository, deploymentID, opts)
+	deploy, resp, err := c.client.Repositories.ListDeploymentStatuses(ctx, owner, repository, deploymentID, opts)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, ErrDeploymentNotFound
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/hookd/pkg/server/deploymentrequest.go
+++ b/hookd/pkg/server/deploymentrequest.go
@@ -18,9 +18,7 @@ var (
 	payloadVersion = []int32{1, 0, 0}
 )
 
-// DeploymentRequestFromEvent creates a deployment request from a Github Deployment Event.
-// The event is validated, and if any fields are missing, an error is returned.
-// Any error from this function should be considered user error.
+// DeploymentRequestMessage creates a deployment request from user input provided to the deployment API.
 func DeploymentRequestMessage(r *DeploymentRequest, deployment *gh.Deployment, deliveryID string) (*types.DeploymentRequest, error) {
 	kube, err := types.KubernetesFromJSONResources(r.Resources)
 	if err != nil {

--- a/hookd/pkg/server/handler_test.go
+++ b/hookd/pkg/server/handler_test.go
@@ -70,6 +70,10 @@ func (g *githubClient) CreateDeployment(ctx context.Context, owner, repository s
 	}
 }
 
+func (g *githubClient) DeploymentStatus(ctx context.Context, owner, repository string, deploymentID int64) (*gh.DeploymentStatus, error) {
+	return nil, nil
+}
+
 type apiKeyStorage struct{}
 
 func (a *apiKeyStorage) Read(team string) ([]byte, error) {

--- a/hookd/pkg/server/handler_test.go
+++ b/hookd/pkg/server/handler_test.go
@@ -71,7 +71,10 @@ func (g *githubClient) CreateDeployment(ctx context.Context, owner, repository s
 }
 
 func (g *githubClient) DeploymentStatus(ctx context.Context, owner, repository string, deploymentID int64) (*gh.DeploymentStatus, error) {
-	return nil, nil
+	return &gh.DeploymentStatus{
+		ID:    gh.Int64(deploymentID),
+		State: gh.String("success"),
+	}, nil
 }
 
 type apiKeyStorage struct{}

--- a/hookd/pkg/server/status_handler.go
+++ b/hookd/pkg/server/status_handler.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/navikt/deployment/hookd/pkg/github"
+	"github.com/navikt/deployment/hookd/pkg/middleware"
+
+	types "github.com/navikt/deployment/common/pkg/deployment"
+	"github.com/navikt/deployment/hookd/pkg/persistence"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	SignatureHeader         = "X-NAIS-Signature"
+	FailedAuthenticationMsg = "failed authentication"
+	MaxTimeSkew             = 30.0
+)
+
+type StatusHandler struct {
+	APIKeyStorage persistence.ApiKeyStorage
+	GithubClient  github.Client
+}
+
+type StatusRequest struct {
+	DeploymentId string `json:"deploymentId"`
+	Team         string `json:"team"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+type StatusResponse struct {
+	Message string                      `json:"message,omitempty"`
+	Status  types.GithubDeploymentState `json:"status,omitempty"`
+}
+
+func (r *StatusResponse) render(w io.Writer) {
+	json.NewEncoder(w).Encode(r)
+}
+
+func (r *StatusRequest) validate() error {
+
+	if len(r.DeploymentId) == 0 {
+		return fmt.Errorf("no deployment id specified")
+	}
+
+	if len(r.Team) == 0 {
+		return fmt.Errorf("no team specified")
+	}
+
+	if math.Abs(float64(r.Timestamp-time.Now().Unix())) > MaxTimeSkew {
+		return fmt.Errorf("request is not within allowed timeframe")
+	}
+
+	return nil
+}
+
+//func (r *DeploymentRequest) GithubDeploymentRequest() gh.DeploymentRequest {
+//	return gh.DeploymentRequest{
+//		Environment: gh.String(r.Cluster),
+//		Ref:         gh.String(r.Ref),
+//		Task:        gh.String(DirectDeployGithubTask),
+//	}
+//}
+//
+
+func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+	var statusResponse StatusResponse
+
+	fields := middleware.RequestLogFields(r)
+	logger := log.WithFields(fields)
+
+	logger.Tracef("Incoming status request")
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		statusResponse.Message = fmt.Sprintf("unable to read request body: %s", err)
+		statusResponse.render(w)
+
+		logger.Error(statusResponse.Message)
+		return
+	}
+
+	encodedSignature := r.Header.Get(SignatureHeader)
+	signature, err := hex.DecodeString(encodedSignature)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		statusResponse.Message = "HMAC digest must be hex encoded"
+		statusResponse.render(w)
+		logger.Errorf("unable to validate team: %s: %s", statusResponse.Message, err)
+		return
+	}
+
+	logger.Tracef("Request has hex encoded data in signature header")
+
+	statusRequest := &StatusRequest{}
+	if err := json.Unmarshal(data, statusRequest); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		statusResponse.Message = fmt.Sprintf("unable to unmarshal request body: %s", err)
+		statusResponse.render(w)
+		logger.Error(statusResponse.Message)
+		return
+	}
+
+	logger.Tracef("Request has valid JSON")
+
+	err = statusRequest.validate()
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		statusResponse.Message = fmt.Sprintf("invalid status request: %s", err)
+		statusResponse.render(w)
+		logger.Error(statusResponse.Message)
+		return
+	}
+
+	logger.Tracef("Request body validated successfully")
+
+	token, err := h.APIKeyStorage.Read(statusRequest.Team)
+
+	if err != nil {
+		if h.APIKeyStorage.IsErrNotFound(err) {
+			w.WriteHeader(http.StatusForbidden)
+			statusResponse.Message = FailedAuthenticationMsg
+			statusResponse.render(w)
+			logger.Errorf("%s: %s", FailedAuthenticationMsg, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusBadGateway)
+		statusResponse.Message = "something wrong happened when communicating with api key service"
+		statusResponse.render(w)
+		logger.Errorf("unable to fetch team apikey from storage: %s", err)
+		return
+	}
+
+	logger.Tracef("Team API key retrieved from storage")
+
+	if !validateMAC(data, []byte(signature), token) {
+		w.WriteHeader(http.StatusForbidden)
+		statusResponse.Message = FailedAuthenticationMsg
+		statusResponse.render(w)
+		logger.Errorf("%s: HMAC signature error", FailedAuthenticationMsg)
+		return
+	}
+
+	logger.Tracef("HMAC signature validated successfully")
+	//
+	//err = h.GithubClient.TeamAllowed(r.Context(), statusRequest.Owner, statusRequest.Repository, statusRequest.Team)
+	//switch err {
+	//case nil:
+	//	logger.Tracef("Team access to repository on GitHub validated successfully")
+	//case github.ErrTeamNotExist, github.ErrTeamNoAccess:
+	//	statusResponse.Message = err.Error()
+	//	w.WriteHeader(http.StatusForbidden)
+	//	statusResponse.render(w)
+	//	logger.Error(err)
+	//	return
+	//default:
+	//	statusResponse.Message = "unable to communicate with GitHub"
+	//	w.WriteHeader(http.StatusBadGateway)
+	//	statusResponse.render(w)
+	//	logger.Errorf("%s: %s", statusResponse.Message, err)
+	//	return
+	//}
+	//
+	//githubRequest := statusRequest.GithubDeploymentRequest()
+	//githubDeployment, err = h.GithubClient.CreateDeployment(r.Context(), statusRequest.Owner, statusRequest.Repository, &githubRequest)
+	//statusResponse.GithubDeployment = githubDeployment
+	//
+	//if err != nil {
+	//	w.WriteHeader(http.StatusBadGateway)
+	//	statusResponse.Message = "unable to create GitHub deployment"
+	//	statusResponse.render(w)
+	//	logger.Errorf("unable to create GitHub deployment: %s", err)
+	//	return
+	//}
+	//
+	//logger = logger.WithField(types.LogFieldDeploymentID, githubDeployment.GetID())
+	//logger.Info("GitHub deployment created successfully")
+	//
+	//deployMsg, err := DeploymentRequestMessage(statusRequest, githubDeployment, statusResponse.CorrelationID)
+	//if err != nil {
+	//	w.WriteHeader(http.StatusBadRequest)
+	//	statusResponse.Message = "unable to create deployment message"
+	//	statusResponse.render(w)
+	//	logger.Errorf("unable to create deployment message: %s", err)
+	//	return
+	//}
+	//
+	//h.DeploymentRequest <- *deployMsg
+	//
+	//w.WriteHeader(http.StatusCreated)
+	//statusResponse.Message = "deployment request accepted and dispatched"
+	//statusResponse.render(w)
+
+	//logger.Info("Deployment request processed successfully")
+}
+
+// validateMAC reports whether messageMAC is a valid HMAC tag for message.
+func validateMAC(message, messageMAC, key []byte) bool {
+	expectedMAC := GenMAC(message, key)
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// GenMAC generates the HMAC signature for a message provided the secret key using SHA256
+func GenMAC(message, key []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(message)
+	return mac.Sum(nil)
+}

--- a/hookd/pkg/server/status_handler.go
+++ b/hookd/pkg/server/status_handler.go
@@ -153,7 +153,11 @@ func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil {
-		if err == github.ErrNoDeploymentStatuses {
+		if err == github.ErrDeploymentNotFound {
+			w.WriteHeader(http.StatusBadRequest)
+			logger.Info("Deployment %d does not exist", statusRequest.DeploymentID)
+			return
+		} else if err == github.ErrNoDeploymentStatuses {
 			w.WriteHeader(http.StatusNoContent)
 			logger.Info("Deployment status requested but none available")
 			return

--- a/hookd/pkg/server/status_handler.go
+++ b/hookd/pkg/server/status_handler.go
@@ -48,7 +48,15 @@ func (r *StatusResponse) render(w io.Writer) {
 func (r *StatusRequest) validate() error {
 
 	if r.DeploymentID == 0 {
-		return fmt.Errorf("no deployment id specified")
+		return fmt.Errorf("no deployment ID specified")
+	}
+
+	if len(r.Owner) == 0 {
+		return fmt.Errorf("no repository owner specified")
+	}
+
+	if len(r.Repository) == 0 {
+		return fmt.Errorf("no repository specified")
 	}
 
 	if len(r.Team) == 0 {

--- a/hookd/pkg/server/status_handler_test.go
+++ b/hookd/pkg/server/status_handler_test.go
@@ -1,0 +1,109 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	types "github.com/navikt/deployment/common/pkg/deployment"
+	"github.com/navikt/deployment/hookd/pkg/server"
+	"github.com/stretchr/testify/assert"
+)
+
+type statusRequest struct {
+	Headers map[string]string
+	Body    json.RawMessage
+}
+
+type statusResponse struct {
+	StatusCode int                   `json:"statusCode"`
+	Body       server.StatusResponse `json:"body"`
+}
+
+type statusTestCase struct {
+	Request  statusRequest  `json:"request"`
+	Response statusResponse `json:"response"`
+}
+
+func testStatusResponse(t *testing.T, recorder *httptest.ResponseRecorder, response statusResponse) {
+	decodedBody := server.StatusResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &decodedBody)
+	assert.NoError(t, err)
+	assert.Equal(t, response.StatusCode, recorder.Code)
+	assert.Equal(t, response.Body.Message, decodedBody.Message)
+	assert.Equal(t, response.Body.Status, decodedBody.Status)
+}
+
+func statusBody(in []byte) []byte {
+	return in
+}
+
+func statusSubTest(t *testing.T, name string) {
+	inFile := fmt.Sprintf("testdata/status/%s", name)
+
+	fixture := fileReader(inFile)
+	data, err := ioutil.ReadAll(fixture)
+	if err != nil {
+		t.Error(data)
+		t.Fail()
+	}
+
+	test := statusTestCase{}
+	err = json.Unmarshal(data, &test)
+	if err != nil {
+		t.Error(data)
+		t.Fail()
+	}
+
+	body := statusBody(test.Request.Body)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/api/v1/status", bytes.NewReader(body))
+
+	for key, val := range test.Request.Headers {
+		request.Header.Set(key, val)
+	}
+
+	// Generate HMAC header for cases where the header should be valid
+	if len(request.Header.Get(server.SignatureHeader)) == 0 {
+		mac := server.GenMAC(body, secretKey)
+		request.Header.Set(server.SignatureHeader, hex.EncodeToString(mac))
+	}
+
+	requests := make(chan types.DeploymentRequest, 1024)
+	statuses := make(chan types.DeploymentStatus, 1024)
+	ghClient := githubClient{}
+	apiKeyStore := apiKeyStorage{}
+
+	handler := server.DeploymentHandler{
+		DeploymentRequest: requests,
+		DeploymentStatus:  statuses,
+		APIKeyStorage:     &apiKeyStore,
+		GithubClient:      &ghClient,
+		Clusters:          validClusters,
+	}
+
+	handler.ServeHTTP(recorder, request)
+
+	testStatusResponse(t, recorder, test.Response)
+}
+
+func TestStatusHandler(t *testing.T) {
+	files, err := ioutil.ReadDir("testdata/status")
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		name := file.Name()
+		t.Run(name, func(t *testing.T) {
+			statusSubTest(t, name)
+		})
+	}
+}

--- a/hookd/pkg/server/status_handler_test.go
+++ b/hookd/pkg/server/status_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	types "github.com/navikt/deployment/common/pkg/deployment"
 	"github.com/navikt/deployment/hookd/pkg/server"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,17 +72,12 @@ func statusSubTest(t *testing.T, name string) {
 		request.Header.Set(server.SignatureHeader, hex.EncodeToString(mac))
 	}
 
-	requests := make(chan types.DeploymentRequest, 1024)
-	statuses := make(chan types.DeploymentStatus, 1024)
 	ghClient := githubClient{}
 	apiKeyStore := apiKeyStorage{}
 
-	handler := server.DeploymentHandler{
-		DeploymentRequest: requests,
-		DeploymentStatus:  statuses,
-		APIKeyStorage:     &apiKeyStore,
-		GithubClient:      &ghClient,
-		Clusters:          validClusters,
+	handler := server.StatusHandler{
+		APIKeyStorage: &apiKeyStore,
+		GithubClient:  &ghClient,
 	}
 
 	handler.ServeHTTP(recorder, request)

--- a/hookd/pkg/server/testdata/status/apikey_not_found.json
+++ b/hookd/pkg/server/testdata/status/apikey_not_found.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "team": "notfound",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 403,
+    "body": {
+      "message": "failed authentication"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/apikey_unavailable.json
+++ b/hookd/pkg/server/testdata/status/apikey_unavailable.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "team": "unavailable",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 502,
+    "body": {
+      "message": "something wrong happened when communicating with api key service"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/empty.json
+++ b/hookd/pkg/server/testdata/status/empty.json
@@ -1,0 +1,10 @@
+{
+  "request": {
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "unable to unmarshal request body: unexpected end of JSON input"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/hmac_wrong_encoding.json
+++ b/hookd/pkg/server/testdata/status/hmac_wrong_encoding.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "headers": {
+      "x-nais-signature": "foobar"
+    },
+    "body": {
+      "deploymentID": 123,
+      "team": "nobody",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "HMAC digest must be hex encoded"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/hmac_wrong_signature.json
+++ b/hookd/pkg/server/testdata/status/hmac_wrong_signature.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "headers": {
+      "x-nais-signature": "672e772440ed7107230c8af1fa94fcbb4b75d69bf64c9618817c557f13b9444b"
+    },
+    "body": {
+      "deploymentID": 123,
+      "team": "nobody",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 403,
+    "body": {
+      "message": "failed authentication"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/invalid_deploymentid.json
+++ b/hookd/pkg/server/testdata/status/invalid_deploymentid.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "body": {
+      "team": "nobody",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "invalid status request: no deployment ID specified"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/invalid_owner.json
+++ b/hookd/pkg/server/testdata/status/invalid_owner.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "team": "nobody",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "invalid status request: no repository owner specified"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/invalid_repository.json
+++ b/hookd/pkg/server/testdata/status/invalid_repository.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "team": "nobody",
+      "owner": "foo"
+    }
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "invalid status request: no repository specified"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/invalid_team.json
+++ b/hookd/pkg/server/testdata/status/invalid_team.json
@@ -1,0 +1,15 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 400,
+    "body": {
+      "message": "invalid status request: no team specified"
+    }
+  }
+}

--- a/hookd/pkg/server/testdata/status/valid.json
+++ b/hookd/pkg/server/testdata/status/valid.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "body": {
+      "deploymentID": 123,
+      "team": "nobody",
+      "owner": "foo",
+      "repository": "bar"
+    }
+  },
+  "response": {
+    "statusCode": 200,
+    "body": {
+      "message": "deployment status retrieved successfully",
+      "status": "success"
+    }
+  }
+}


### PR DESCRIPTION
This endpoint exposes deployment statuses, so that clients can query the state of their deployment without having access to GitHub credentials.